### PR TITLE
Updated README

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,5 @@
 {
     "license": "CC-BY-NC-SA-4.0",
-    "description": "<p>This corpus of annotated <a href=\"https://musescore.org\">MuseScore</a> files has been created within the <a href=\"https://github.com/DCMLab/dcml_corpora\">DCML corpus initiative</a> and employs the <a href=\"https://github.com/DCMLab/standards\">DCML harmony annotation standard</a>. It is one out of forty similar corpora that have been grouped together to <a href=\"https://doi.org/10.5281/zenodo.13844105\">The Distant Listening Corpus: A modular infrastructure for the empirical study of (an)notated music</a> which comes with a data report that is currently under review.</p>\n\n<p>The dataset lives on GitHub (link under &quot;Related identifiers&quot;) and is stored on Zenodo purely for conservation and automatic DOI generation for new GitHub releases. For technical reasons, we include only brief, generic instructions on how to use the data. For more detailed documentation, please refer to the dataset&#39;s GitHub page.</p>\n\n<p><strong>What is included</strong></p>\n\n<p>The dataset includes annotated MusicScores <strong>.mscx</strong> files that have been created with <a href=\"https://github.com/musescore/MuseScore/releases/tag/v3.6.2\">MuseScore 3.6.2</a> and can be opened with any MuseScore 3, or later version. Apart from that, the score information (measures, notes, markup, and harmony labels) have been extracted in the form of TSV files which can be found respectively in the folders <code>measures</code>, <code>notes</code>, <code>chords</code>, and <code>harmonies</code>. They have been extracted with the Python library <a href=\"https://pypi.org/project/ms3/\">ms3</a> and its documentation has a <a href=\"https://ms3.readthedocs.io/columns\">column glossary for looking up the meaning of a column</a>.</p>\n\n<p><strong>Getting the data</strong></p>\n\n<p>You can download the dataset as a ZIP file from Zenodo or GitHub.</p>\n\n<p>Apart from that, there is the possibility to git-clone the GitHub repository to your disk. This has the advantage that it allows to version-control any changes you want to make to the dataset and to ask for your changes to be included (&quot;merged&quot;) in a future version.</p>",
     "contributors": [
         {
             "orcid": "0000-0002-6329-7492",
@@ -23,7 +22,7 @@
             "name": "Victor Zheng"
         }
     ],
-    "title": "Sergei Rachmaninoff – Variations on a Theme of Corelli, Op. 42",
+    "title": "Sergei Rachmaninoff – Variations on a Theme of Corelli, Op. 42 (A corpus of annotated scores)",
     "keywords": [
         "music research",
         "music theory",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Version](https://img.shields.io/github/v/release/DCMLab/rachmaninoff_piano?display_name=tag)
-[![DOI](https://zenodo.org/badge/520217150.svg)](https://zenodo.org/badge/latestdoi/520217150)
+[![DOI](https://zenodo.org/badge/520217150.svg)](https://doi.org/10.5281/zenodo.14984155)
 ![GitHub repo size](https://img.shields.io/github/repo-size/DCMLab/rachmaninoff_piano)
 ![License](https://img.shields.io/badge/license-CC%20BY--NC--SA%204.0-9cf)
 
@@ -25,7 +25,60 @@ that the composer himself, champion of the instrument that he was, found them un
 tonal substance out of which this cycle's impressive digressions and interpolations are forged, and comparing the
 outputs of each of these variations should provide fertile ground for quantitative study of variational technique.
 
-## Cite as
+## Getting the data
+
+* download repository as a [ZIP file](https://github.com/DCMLab/rachmaninoff_piano/archive/main.zip)
+* download a [Frictionless Datapackage](https://specs.frictionlessdata.io/data-package/) that includes concatenations
+  of the TSV files in the four folders (`measures`, `notes`, `chords`, and `harmonies`) and a JSON descriptor:
+  * [rachmaninoff_piano.zip](https://github.com/DCMLab/rachmaninoff_piano/releases/latest/download/rachmaninoff_piano.zip)
+  * [rachmaninoff_piano.datapackage.json](https://github.com/DCMLab/rachmaninoff_piano/releases/latest/download/rachmaninoff_piano.datapackage.json)
+* clone the repo: `git clone https://github.com/DCMLab/rachmaninoff_piano.git` 
+
+
+## Data Formats
+
+Each piece in this corpus is represented by five files with identical name prefixes, each in its own folder. 
+For example, the variation theme has the following files:
+
+* `MS3/op42_01a.mscx`: Uncompressed MuseScore 3.6.2 file including the music and annotation labels.
+* `notes/op42_01a.notes.tsv`: A table of all note heads contained in the score and their relevant features (not each of them represents an onset, some are tied together)
+* `measures/op42_01a.measures.tsv`: A table with relevant information about the measures in the score.
+* `chords/op42_01a.chords.tsv`: A table containing layer-wise unique onset positions with the musical markup (such as dynamics, articulation, lyrics, figured bass, etc.).
+* `harmonies/op42_01a.harmonies.tsv`: A table of the included harmony labels (including cadences and phrases) with their positions in the score.
+
+Each TSV file comes with its own JSON descriptor that describes the meanings and datatypes of the columns ("fields") it contains,
+follows the [Frictionless specification](https://specs.frictionlessdata.io/tabular-data-resource/),
+and can be used to validate and correctly load the described file. 
+
+### Opening Scores
+
+After navigating to your local copy, you can open the scores in the folder `MS3` with the free and open source score
+editor [MuseScore](https://musescore.org). Please note that the scores have been edited, annotated and tested with
+[MuseScore 3.6.2](https://github.com/musescore/MuseScore/releases/tag/v3.6.2). 
+MuseScore 4 has since been released which renders them correctly but cannot store them back in the same format.
+
+### Opening TSV files in a spreadsheet
+
+Tab-separated value (TSV) files are like Comma-separated value (CSV) files and can be opened with most modern text
+editors. However, for correctly displaying the columns, you might want to use a spreadsheet or an addon for your
+favourite text editor. When you use a spreadsheet such as Excel, it might annoy you by interpreting fractions as
+dates. This can be circumvented by using `Data --> From Text/CSV` or the free alternative
+[LibreOffice Calc](https://www.libreoffice.org/download/download/). Other than that, TSV data can be loaded with
+every modern programming language.
+
+### Loading TSV files in Python
+
+Since the TSV files contain null values, lists, fractions, and numbers that are to be treated as strings, you may want
+to use this code to load any TSV files related to this repository (provided you're doing it in Python). After a quick
+`pip install -U ms3` (requires Python 3.10) you'll be able to load any TSV like this:
+
+```python
+import ms3
+
+labels = ms3.load_tsv("harmonies/op42_01a.harmonies.tsv")
+notes = ms3.load_tsv("notes/op42_01a.notes.tsv"")
+```
+
 
 ## Version history
 
@@ -34,6 +87,10 @@ See the [GitHub releases](https://github.com/DCMLab/rachmaninoff_piano/releases)
 ## Questions, Suggestions, Corrections, Bug Reports
 
 Please [create an issue](https://github.com/DCMLab/rachmaninoff_piano/issues) and/or feel free to fork and submit pull requests.
+
+## Cite as
+
+_Johannes Hentschel, Yannis Rammos, Markus Neuwirth, & Martin Rohrmeier. (2025). Sergei Rachmaninoff – Variations on a Theme of Corelli, Op. 42 [Data set]. Zenodo. https://doi.org/10.5281/zenodo.14984155_
 
 ## License
 
@@ -44,6 +101,12 @@ Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License 
 ## Scores
 
 These scores were specially typeset for this project by Matthias Schabow following the reissued 1931 first edition, which is itself available via the IMSLP MIT Archive Project.
+
+## File naming convention
+
+```regex
+op42_(?<movement>\d{2}[ab]?)
+```
 
 ## Overview
 |file_name|measures|labels|standard|    annotators     |     reviewers     |


### PR DESCRIPTION
This is a README file for a data repository originating from the [DCML corpus initiative](https://github.com/DCMLab/dcml_corpora)
and serves as welcome page for both 

* the GitHub repo [https://github.com/DCMLab/rachmaninoff_piano](https://github.com/DCMLab/rachmaninoff_piano) and the corresponding
* documentation page [https://dcmlab.github.io/rachmaninoff_piano](https://dcmlab.github.io/rachmaninoff_piano)

For information on how to obtain and use the dataset, please refer to [this documentation page](https://dcmlab.github.io/rachmaninoff_piano/introduction).

# Sergei Rachmaninoff – Variations on a Theme of Corelli, Op. 42

This corpus of annotated [MuseScore](https://musescore.org) files has been created within
the [DCML corpus initiative](https://github.com/DCMLab/dcml_corpora) and employs
the [DCML harmony annotation standard](https://github.com/DCMLab/standards).
It represents Sergei Rachmaninoff's virtuosic op. 42 Variations (1931). This work, written on Lake Lucerne in
Switzerland, reflects the style of the composer's reticent late period. The title is something of a misnomer, as the
theme is in fact the traditional La Folia, used widely by composers of the 17th and 18th centuries including Vivaldi,
Händel, and indeed Corelli. Rachmaninoff tears this venerable theme to shreds with pianistic pyrotechnics so difficult
that the composer himself, champion of the instrument that he was, found them unplayable. Our annotations reveal the
tonal substance out of which this cycle's impressive digressions and interpolations are forged, and comparing the
outputs of each of these variations should provide fertile ground for quantitative study of variational technique.

## Getting the data

* download repository as a [ZIP file](https://github.com/DCMLab/rachmaninoff_piano/archive/main.zip)
* download a [Frictionless Datapackage](https://specs.frictionlessdata.io/data-package/) that includes concatenations
  of the TSV files in the four folders (`measures`, `notes`, `chords`, and `harmonies`) and a JSON descriptor:
  * [rachmaninoff_piano.zip](https://github.com/DCMLab/rachmaninoff_piano/releases/latest/download/rachmaninoff_piano.zip)
  * [rachmaninoff_piano.datapackage.json](https://github.com/DCMLab/rachmaninoff_piano/releases/latest/download/rachmaninoff_piano.datapackage.json)
* clone the repo: `git clone https://github.com/DCMLab/rachmaninoff_piano.git` 


## Data Formats

Each piece in this corpus is represented by five files with identical name prefixes, each in its own folder. 
For example, the variation theme has the following files:

* `MS3/op42_01a.mscx`: Uncompressed MuseScore 3.6.2 file including the music and annotation labels.
* `notes/op42_01a.notes.tsv`: A table of all note heads contained in the score and their relevant features (not each of them represents an onset, some are tied together)
* `measures/op42_01a.measures.tsv`: A table with relevant information about the measures in the score.
* `chords/op42_01a.chords.tsv`: A table containing layer-wise unique onset positions with the musical markup (such as dynamics, articulation, lyrics, figured bass, etc.).
* `harmonies/op42_01a.harmonies.tsv`: A table of the included harmony labels (including cadences and phrases) with their positions in the score.

Each TSV file comes with its own JSON descriptor that describes the meanings and datatypes of the columns ("fields") it contains,
follows the [Frictionless specification](https://specs.frictionlessdata.io/tabular-data-resource/),
and can be used to validate and correctly load the described file. 

### Opening Scores

After navigating to your local copy, you can open the scores in the folder `MS3` with the free and open source score
editor [MuseScore](https://musescore.org). Please note that the scores have been edited, annotated and tested with
[MuseScore 3.6.2](https://github.com/musescore/MuseScore/releases/tag/v3.6.2). 
MuseScore 4 has since been released which renders them correctly but cannot store them back in the same format.

### Opening TSV files in a spreadsheet

Tab-separated value (TSV) files are like Comma-separated value (CSV) files and can be opened with most modern text
editors. However, for correctly displaying the columns, you might want to use a spreadsheet or an addon for your
favourite text editor. When you use a spreadsheet such as Excel, it might annoy you by interpreting fractions as
dates. This can be circumvented by using `Data --> From Text/CSV` or the free alternative
[LibreOffice Calc](https://www.libreoffice.org/download/download/). Other than that, TSV data can be loaded with
every modern programming language.

### Loading TSV files in Python

Since the TSV files contain null values, lists, fractions, and numbers that are to be treated as strings, you may want
to use this code to load any TSV files related to this repository (provided you're doing it in Python). After a quick
`pip install -U ms3` (requires Python 3.10) you'll be able to load any TSV like this:

```python
import ms3

labels = ms3.load_tsv("harmonies/op42_01a.harmonies.tsv")
notes = ms3.load_tsv("notes/op42_01a.notes.tsv"")
```


## Version history

See the [GitHub releases](https://github.com/DCMLab/rachmaninoff_piano/releases).

## Questions, Suggestions, Corrections, Bug Reports

Please [create an issue](https://github.com/DCMLab/rachmaninoff_piano/issues) and/or feel free to fork and submit pull requests.

## Cite as

_Johannes Hentschel, Yannis Rammos, Markus Neuwirth, & Martin Rohrmeier. (2025). Sergei Rachmaninoff – Variations on a Theme of Corelli, Op. 42 [Data set]. Zenodo. https://doi.org/10.5281/zenodo.14984155_

## License

Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License ([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)).

![cc-by-nc-sa-image](https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png)

## Scores

These scores were specially typeset for this project by Matthias Schabow following the reissued 1931 first edition, which is itself available via the IMSLP MIT Archive Project.

## File naming convention

```regex
op42_(?<movement>\d{2}[ab]?)
```
